### PR TITLE
Schema Loader: Check/load all schemas together

### DIFF
--- a/pages/schema_library.py
+++ b/pages/schema_library.py
@@ -102,7 +102,12 @@ def schema_loading_container(
             if response.errors:
                 loading_container.update(label="❌ Load failed ...", state="error", expanded=True)
                 loading_container.error("Infrahub doesn't like it!", icon="🚨")
-                loading_container.exception(response.errors)
+                if "Unable to find" in response.errors["errors"][0]["message"]:
+                    loading_container.error(
+                        "You might be missing schema dependencies. Please load the schemas' dependencies first!",
+                        icon="🔍",
+                    )
+                loading_container.error(response.errors["errors"][0]["message"])
             else:
                 loading_container.update(label="✅ Schema loaded!", state="complete", expanded=True)
                 st.session_state.extensions_states[schema_extension] = SchemaState.LOADED

--- a/pages/schema_loader.py
+++ b/pages/schema_loader.py
@@ -16,6 +16,12 @@ menu_with_redirect()
 if "is_upload_valid" not in st.session_state:
     st.session_state.is_upload_valid = False
 
+if "schemas" not in st.session_state:
+    st.session_state.schemas = []
+
+if "apply_button" not in st.session_state:
+    st.session_state.apply_button_disabled = True
+
 # Check for generated files in session state
 generated_files = st.session_state.get("generated_files", [])
 
@@ -32,19 +38,12 @@ else:
         help="If you need help building your schema, feel free to reach out to Opsmill team!",
     )
 
-apply_button = st.button(
-    label=f"🚀 Load to :blue[__*{st.session_state.infrahub_branch}*__] branch in Infrahub",
-    type="primary",
-    use_container_width=True,
-)
-
-result_container = st.container(border=False)
-
 # If something is uploaded or available in session state...
-if not apply_button and st.session_state.uploaded_files and len(st.session_state.uploaded_files) > 0:
+if st.session_state.uploaded_files and len(st.session_state.uploaded_files) > 0:
     st.session_state.is_upload_valid = True
     preview_container = st.container(border=False)
 
+    st.session_state.schemas = []
     for uploaded_file in st.session_state.uploaded_files:
         file_name = uploaded_file["name"] if isinstance(uploaded_file, dict) else uploaded_file.name
         file_content = uploaded_file["content"] if isinstance(uploaded_file, dict) else uploaded_file.read()
@@ -55,52 +54,51 @@ if not apply_button and st.session_state.uploaded_files and len(st.session_state
                 schema_content = yaml.safe_load(file_content)
                 preview_status.success("This YAML file is valid", icon="✅")
                 preview_status.code(yaml.safe_dump(schema_content), language="yaml", line_numbers=True)
-
-                # Then check schema over Infrahub instance
-                schema_check_result = check_schema(branch=st.session_state.infrahub_branch, schemas=[schema_content])
-
-                if schema_check_result:
-                    # If something went wrong
-                    if not schema_check_result.success:
-                        st.session_state.is_upload_valid = False
-                        preview_status.error("Infrahub doesn't like it!", icon="🚨")
-                        if schema_check_result.response:
-                            # TODO: Improve error message
-                            preview_status.exception(exception=BaseException(schema_check_result.response))
-                        msg.toast(body=f"Error encountered for {file_name}", icon="🚨")
-                    else:
-                        # Otherwise we load the diff
-                        preview_status.success("This is the diff against current schema", icon="👇")
-                        if schema_check_result.response:
-                            preview_status.code(yaml.safe_dump(schema_check_result.response), language="yaml")
-                        msg.toast(body=f"Loading complete for {file_name}", icon="👍")
-
+                st.session_state.schemas.append(schema_content)
             except yaml.YAMLError as exc:
                 st.session_state.is_upload_valid = False
                 preview_container.error("This file contains a YAML error!", icon="🚨")
                 preview_status.exception(exception=exc)  # TODO: Improve that?
                 msg.toast(body=f"Error encountered for {file_name}", icon="🚨")
 
+    with preview_container.status("Schema check ...") as preview_status:
+        # Then check schema over Infrahub instance
+        schema_check_result = check_schema(branch=st.session_state.infrahub_branch, schemas=st.session_state.schemas)
+
+        if schema_check_result:
+            # If something went wrong
+            if not schema_check_result.success:
+                st.session_state.is_upload_valid = False
+                preview_status.error("Infrahub doesn't like it!", icon="🚨")
+                if schema_check_result.response:
+                    # TODO: Improve error message
+                    preview_status.exception(exception=BaseException(schema_check_result.response))
+                msg.toast(body=f"Error encountered for {file_name}", icon="🚨")
+            else:
+                # Otherwise we load the diff
+                preview_status.success("This is the diff against current schema", icon="👇")
+                if schema_check_result.response:
+                    preview_status.code(yaml.safe_dump(schema_check_result.response), language="yaml")
+                msg.toast(body=f"Loading complete for {file_name}", icon="👍")
+                st.session_state.apply_button_disabled = False
+
+
+apply_button = st.button(
+    label=f"🚀 Load to :blue[__*{st.session_state.infrahub_branch}*__] branch in Infrahub",
+    type="primary",
+    use_container_width=True,
+    disabled=st.session_state.apply_button_disabled,
+)
+
+result_container = st.container(border=False)
+
 # If someone clicks the button and upload is ok
 if apply_button and st.session_state.is_upload_valid:
     with result_container.status("Loading schema ...") as result_status:
-        schemas_data = []
         result_status.update(expanded=True)
 
-        if st.session_state.uploaded_files:
-            for uploaded_file in st.session_state.uploaded_files:
-                try:
-                    file_name = uploaded_file["name"] if isinstance(uploaded_file, dict) else uploaded_file.name
-                    file_content = uploaded_file["content"] if isinstance(uploaded_file, dict) else uploaded_file.read()
-                    st.write(f"Loading `{file_name}` ...")
-                    schemas_data.append(yaml.safe_load(file_content))
-
-                except yaml.YAMLError as exc:
-                    result_status.error(f"This file {file_name} contains an error!", icon="🚨")
-                    result_status.write(exc)
-
         st.write("Calling Infrahub API...")
-        response = load_schema(branch=st.session_state.infrahub_branch, schemas=schemas_data)
+        response = load_schema(branch=st.session_state.infrahub_branch, schemas=st.session_state.schemas)
         st.write("Computing results...")
 
         if response:


### PR DESCRIPTION
- Validate YAML for each schema, add valid schemas to a list and then check/load all schemas together in-case schemas depend on each other.
- Disable apply button until schemas are checked and validated
- Add better error message for schema library